### PR TITLE
add-alb-cert-validation

### DIFF
--- a/modules/account-routing/main.tf
+++ b/modules/account-routing/main.tf
@@ -68,6 +68,11 @@ resource "aws_route53_record" "cert_validation" {
   zone_id         = aws_route53_zone.subdomain_zone.zone_id
 }
 
+resource "aws_acm_certificate_validation" "cert_validation" {
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
 data "aws_lb_listener" "public_alb" {
   load_balancer_arn = data.aws_lb.public_alb.arn
   port              = 443
@@ -75,5 +80,5 @@ data "aws_lb_listener" "public_alb" {
 
 resource "aws_lb_listener_certificate" "cert" {
   listener_arn    = data.aws_lb_listener.public_alb.arn
-  certificate_arn = aws_acm_certificate.cert.arn
+  certificate_arn = aws_acm_certificate_validation.cert_validation.certificate_arn
 }


### PR DESCRIPTION
Ticket: https://app.zenhub.com/workspaces/cloud-pathfinder-5e4dbb426c3c6af8dcbf06a7/issues/bcgov/cloud-pathfinder/1226

Tested using `source = "git::git@github.com:BCDevOps/terraform-octk-aws-sea-routing.git//.?ref=add-alb-cert-validation"` in the LZ2 DNS module. 